### PR TITLE
Move initialization outside of the test loop

### DIFF
--- a/uuid-benchmark.php
+++ b/uuid-benchmark.php
@@ -34,8 +34,9 @@ $results['ramsey-pecl'] = $watch->stop('ramsey-pecl');
 
 $watch->start('ramsey-nopecl');
 
+\Ramsey\Uuid\Uuid::setFactory(new \Ramsey\Uuid\UuidFactory());
+
 for ($i = 0; $i < ITERATIONS; ++$i) {
-    \Ramsey\Uuid\Uuid::setFactory(new \Ramsey\Uuid\UuidFactory());
     $x = (string) \Ramsey\Uuid\Uuid::uuid4();
 }
 
@@ -43,11 +44,12 @@ $results['ramsey-nopecl'] = $watch->stop('ramsey-nopecl');
 
 $watch->start('ramsey-randomlib');
 
+$uuidFactory = new \Ramsey\Uuid\UuidFactory();
+// Using low-strength generator by default
+$uuidFactory->setRandomGenerator(new \Ramsey\Uuid\Generator\RandomLibAdapter());
+\Ramsey\Uuid\Uuid::setFactory($uuidFactory);
+
 for ($i = 0; $i < ITERATIONS; ++$i) {
-    $uuidFactory = new \Ramsey\Uuid\UuidFactory();
-    // Using low-strength generator by default
-    $uuidFactory->setRandomGenerator(new \Ramsey\Uuid\Generator\RandomLibAdapter());
-    \Ramsey\Uuid\Uuid::setFactory($uuidFactory);
     $x = (string) \Ramsey\Uuid\Uuid::uuid4();
 }
 
@@ -56,10 +58,11 @@ $results['ramsey-randomlib'] = $watch->stop('ramsey-randomlib');
 if (PHP_MAJOR_VERSION >= 7) {
     $watch->start('ramsey-php7');
 
+    $uuidFactory = new \Ramsey\Uuid\UuidFactory();
+    $uuidFactory->setRandomGenerator(new \Ramsey\Uuid\Benchmark\Php7Generator());
+    \Ramsey\Uuid\Uuid::setFactory($uuidFactory);
+
     for ($i = 0; $i < ITERATIONS; ++$i) {
-        $uuidFactory = new \Ramsey\Uuid\UuidFactory();
-        $uuidFactory->setRandomGenerator(new \Ramsey\Uuid\Benchmark\Php7Generator());
-        \Ramsey\Uuid\Uuid::setFactory($uuidFactory);
         $x = (string) \Ramsey\Uuid\Uuid::uuid4();
     }
 


### PR DESCRIPTION
Propose this PR as we should test pure generation and not initialization.

Initial benchmark:

```
            PECL | 0.0090 sec/10000 | 0.0000009 sec/one
         RHUMSAA | 0.2410 sec/10000 | 0.0000241 sec/one
     RAMSEY-PECL | 0.4060 sec/10000 | 0.0000406 sec/one
   RAMSEY-NOPECL | 0.7350 sec/10000 | 0.0000735 sec/one
RAMSEY-RANDOMLIB | 7.1810 sec/10000 | 0.0007181 sec/one
```

Clean benchmark:

```
            PECL | 0.0090 sec/10000 | 0.0000009 sec/one
         RHUMSAA | 0.2310 sec/10000 | 0.0000231 sec/one
     RAMSEY-PECL | 0.3940 sec/10000 | 0.0000394 sec/one
   RAMSEY-NOPECL | 0.3290 sec/10000 | 0.0000329 sec/one
RAMSEY-RANDOMLIB | 1.8550 sec/10000 | 0.0001855 sec/one
```
